### PR TITLE
fixed parameters order bug

### DIFF
--- a/lib/screens/home/addevent.dart
+++ b/lib/screens/home/addevent.dart
@@ -107,7 +107,7 @@ class _AddEventPageState extends State<AddEventPage> {
                   RaisedButton(
                     onPressed: () async {
                       await _data.updatePostData(
-                          title, location, time, typeOfEvent, description);
+                          location, time, title, typeOfEvent, description);
                       showAlertDialog(context);
                       Navigator.of(context).pop();
                     },

--- a/lib/services/database.dart
+++ b/lib/services/database.dart
@@ -21,11 +21,11 @@ class DatabaseService {
   final CollectionReference postCollection =
       Firestore.instance.collection('posts');
 
-  Future updatePostData(String coordinates, String time, String title,
+  Future updatePostData(String location, String time, String title,
       String eventType, String description) async {
     return await postCollection.document(uid).setData({
-      'location': coordinates,
-      'time:': time,
+      'location': location,
+      'time': time,
       'title': title,
       'eventType': eventType,
       'description': description


### PR DESCRIPTION
the order of the parameters passed in were wrong so the data stored in Firestore was off. it's fixed now